### PR TITLE
enable uploading files by pasting them

### DIFF
--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -293,15 +293,20 @@
         editorBody.onpaste = function(e) {
           var clipboardData = e.clipboardData || window.clipboardData;
           var items = clipboardData && clipboardData.items;
-          var files = Array.from(items).filter(function(item) {
+          var files = items && Array.from(items).filter(function(item) {
             return item.kind === "file";
           });
 
-          files.forEach(function(file) {
-            uploadFile(file.getAsFile(), $editorBody)
-          })
-          
-          return false
+          if (files && files.length > 0) {
+            files.forEach(function(file) {
+              uploadFile(file.getAsFile(), $editorBody)
+            })
+
+            return false
+          }
+
+          // allow event to propagate if paste did not have any files
+          return true
         };
 
         function uploadFile(file, $editorBody) {

--- a/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
+++ b/lib/gollum/public/gollum/javascript/editor/gollum.editor.js
@@ -278,15 +278,36 @@
           $editorBody.removeClass('dragging');
           return false;
         };
+
         editorBody.ondrop = function(e) {
           debug("dropped file");
           e.preventDefault();
           $editorBody.removeClass('dragging').addClass('uploading');
 
-          var file = e.dataTransfer.files[0],
-              formData = new FormData();
-          formData.append('file', file);
+          var file = e.dataTransfer.files[0];
+          uploadFile(file, $editorBody)
+
+          return false;
+        };
+
+        editorBody.onpaste = function(e) {
+          var clipboardData = e.clipboardData || window.clipboardData;
+          var items = clipboardData && clipboardData.items;
+          var files = Array.from(items).filter(function(item) {
+            return item.kind === "file";
+          });
+
+          files.forEach(function(file) {
+            uploadFile(file.getAsFile(), $editorBody)
+          })
           
+          return false
+        };
+
+        function uploadFile(file, $editorBody) {
+          var formData = new FormData();
+          formData.append('file', file);
+
           $.ajax({
             url: routePath('upload_file'),
             data: formData,
@@ -312,14 +333,12 @@
               if (data.status == 409) {
                 alert('This file already exists.');
               } else {
-                alert('Error uploading file: ' + textStatus + ' ' + errorThrown);    
+                alert('Error uploading file: ' + textStatus + ' ' + errorThrown);
               }
               $editorBody.removeClass('uploading');
             }
           });
-
-          return false;
-        };
+        }
       } // EditorHas.dragDropUpload
     } // EditorHas.baseEditorMarkup
   };


### PR DESCRIPTION
Note:
- Also need to update _ace_. See PR: https://github.com/no-lodging-or-fresh-baked-cookies/ace/pull/2
This PR does not include that diff (the replaced _ace_) because the diff is massive... we can include it after review

Testing that it works:
- Clone this branch (`paste-upload-files`)
- Also clone the updated ace branch (`add-copy-paste-monk`)
- Execute this script - be sure to update `GOLLUM_DIR` and `ACE_DIR` accordingly:
```zsh
 #! env /bin/zsh
GOLLUM_DIR="/path/to/gollum"
ACE_DIR="/path/to/ace"

cd $GOLLUM_DIR
echo "Removing old ace directory"
rm -rf lib/gollum/public/gollum/javascript/ace
echo "Done\n"


echo "rebuilding ace project..."
cd $ACE_DIR
node ./Makefile.dryice.js -nc  -target $GOLLUM_DIR/lib/gollum/public/gollum/javascript/ > /dev/null
mv $GOLLUM_DIR/lib/gollum/public/gollum/javascript/src-noconflict $GOLLUM_DIR/lib/gollum/public/gollum/javascript/ace
echo "Done.\n"

echo "precompiling assets..."
cd $GOLLUM_DIR
bundle exec rake precompile
echo "Done.\n"

echo Starting server
bundle exec bin/gollum  --allow-uploads page
```